### PR TITLE
Add option to store previous flows in MotionCompensationPyramidal

### DIFF
--- a/src/ewiz/algorithms/mc/pyramidal.py
+++ b/src/ewiz/algorithms/mc/pyramidal.py
@@ -124,7 +124,7 @@ class MotionCompensationPyramidal(MotionCompensationBase):
         )
         return loss
 
-    def optimize(self, events: np.ndarray) -> None:
+    def optimize(self, events: np.ndarray, store_flow: bool = False) -> None:
         """Main optimization function."""
         print("# ===== Starting Optimization ===== #")
         print(f"Total degrees of freedom is {2*self.total_num_patches}...")
@@ -133,6 +133,8 @@ class MotionCompensationPyramidal(MotionCompensationBase):
         patch_flows = update_fine_to_coarse_flow(patch_flows)
         print("# ===== Flow Refined ===== #")
         self.patch_flows = patch_flows
+        if store_flow:
+            self.optimized_patch_flows = self.patch_flows.copy()
         return patch_flows, optimizer_out
 
     # TODO: Modify way I get flow


### PR DESCRIPTION
### Description

Updates the [`MotionCompensationPyramidal`](https://github.com/CIRS-Girona/ewiz/blob/main/src/ewiz/algorithms/mc/pyramidal.py) class to allow saving the previously computed flows according to issue #8. 